### PR TITLE
Bug-Fix: Default Page refresh prevented

### DIFF
--- a/Frontend/src/components/Register/RegisterForm.tsx
+++ b/Frontend/src/components/Register/RegisterForm.tsx
@@ -33,7 +33,7 @@ const RegisterForm: React.FC = () => {
         className="mt-4 w-100"
         variant="primary"
         type="submit"
-        onClick={() => handleRegister(username, password, navigate)}
+        onClick={(e) => handleRegister(e,username, password, navigate)}
       >
         {REGISTER}
       </Button>

--- a/Frontend/src/services/authServices/handleRegister.ts
+++ b/Frontend/src/services/authServices/handleRegister.ts
@@ -5,10 +5,12 @@ import { REGISTER_API_URL } from "../../constants/API_URLS";
 import { isPasswordValid, isUsernameValid } from "../../helpers/username_passwordValidateHelper";
 
 const handleRegister = async (
+  e: React.FormEvent,
   username: string,
   password: string,
   navigate: NavigateFunction
 ) => {  
+  e.preventDefault();
   if (username.trim() !== "" && password.trim() !== "") {
     if(isUsernameValid(username)){
       if(isPasswordValid(password)){


### PR DESCRIPTION
Issue: A page refresh occurred when the register button was clicked, which prevented the form from being submitted.
Fix: Utilized the preventDefault method on the form's event object to prevent the page from refreshing by default.